### PR TITLE
Update config step titles

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -8,7 +8,7 @@ before:
     title: Plan the move
     body: 01_make-a-plan.md
 steps:
-  - title: Plan the move
+  - title: Plan the migration
     description: Explore your options for making the move to GitHub
     event: issues.closed
     link: https://github.com/{{ user.username }}/{{ course.template.name }}/issues/1
@@ -36,7 +36,7 @@ steps:
         data:
           issueURL: '%actions.new_issue.data.html_url%'
 
-  - title: Make the move
+  - title: Complete the Import
     description: Publish your project on GitHub
     event: push
     link: https://github.com/{{ user.username }}/{{ course.template.name }}/issues


### PR DESCRIPTION
⚠️  Wait to merge until 👍  from @JasonEtco 

> PSA: No one change the titles of steps (or courses for that matter). The system is not yet built to handle that.

This PR updates some step title names to reflect content updates that were made in PR https://github.com/githubtraining/migrating-your-repository/pull/3 